### PR TITLE
Renames icon div

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
         <div class="row-details">
           <h4 class="list-group-item-heading">{{ site.author }}</h4>
           <p class="list-group-item-text">{{ site.about }}</p>
-          <div class="social-links">{% include social_links.html %}</div>
+          <div class="fa-icons">{% include social_links.html %}</div>
         </div>
         <div class="navbar-header pull-right">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -58,11 +58,6 @@ p.info a {
     max-width: 100%;
     height: auto;
 }
-/*.social-links {*/
-    /*position: absolute;*/
-    /*top: 0px;*/
-    /*right: 20px;*/
-/*}*/
 .social-icons {
     margin: 20px 0 0;
 }


### PR DESCRIPTION
Some uBlock filters will remove HTML elements with "social-links" in the class name, this is a work-around for that.